### PR TITLE
updated install.html for info with xsm install error

### DIFF
--- a/install.html
+++ b/install.html
@@ -103,12 +103,23 @@ yum install bison
             You may get some warnings and they can be ignored. If you get any <b>fatal error</b>,
             then install the following dependencies and try running "make" again : <br>
             <b>sudo apt-get install libreadline-dev</b> <br>
-            <b>sudo apt-get install lib6-dev</b> <br>
+            <b>sudo apt-get install libc6-dev</b> <br>
             If any other dependencies are missing (this depends on your system configuration), you have to install the missing dependencies
             and run "make" again.
+	    (Optional) While running "./xsm" after Step 2 if you get this error:<br>
+		  <i>/usr/bin/ld: cannot find -ll
+		  collect2: error: ld returned 1 exit status</i>
+		  Then you need to install:<br>
+		  <b>sudo apt-get install libfl-dev</b> <br>
+		  and edit the <b>Makefile</b> of <b>xsm_dev</b> folder, to proceed 
+		  find the line where "-ll" is used as option and update it to "-lfl" to use the "flex" library we installed above.
+	    Now you can run "make" again after navigating into the folder <b>xsm_expl</b> through the terminal.
           </p></li>
           <li id="otis">2. Type "cd ../xfs-interface/" and type "./init".</li>
-        </ul>
+	  <li id="otis">3.(Optional) Add this line <b>#!/usr/bin/env bash</b> as first line to the <b>xsm</b> file in <b>xsm_expl</b> folder.</li>
+          This step is for those who don't have <b>bash</b> or <b>sh</b> as their "default shell" and therefore may be using other 
+	  customizable shells like <b>zsh</b>, etc as their default shell. You can check your default shell by using <b>echo $SHELL</b> in terminal.
+	</ul>
     </p>
     <p>The usage instructions for the XSM simulator can be found <a href="xsmusagespec.html" target="_blank"> here</a>.</p>
 


### PR DESCRIPTION
1. Updated and removed the` lib6-dev `package installation command as there is no such package, the closest is ` libc6-dev` package which is installed by default in most systems.

1. Installed `libfl-dev`  (needed for flex) for **Linux Mint**, etc or any system which had their this particular package removed by subsequent updates of the OS. I found that in _vanilla Linux Mint_ (powered up in VM) the `libfl-dev` package was present by default but was not present in my hard-disk installed and _updated_ Linux Mint. So I replaced the `-ll` with `-lfl` (using the **fl** library) in the `cc` line of the `Makefile` present in xsm_dev.

1. Using any editor vi or nano, added  `#!/usr/bin/env bash` line as first line to the executable **xsm** file in xsm_expl folder so that regardless of which shell the user is using the executable **xsm** will always be run on the **_bash_** shell as how the **xsm** was natively written to run.

Added updated Makefile [here](https://github.com/faruk13/silcnitc-compiler-updated/blob/master/Makefile).
Added updated xsm file [here](https://github.com/faruk13/silcnitc-compiler-updated/blob/master/xsm).